### PR TITLE
Fix image pullback issue in Kafka and MongoDB due to Bitnami image migration

### DIFF
--- a/roles/core/templates/cdac5gc-5g-multiple-dnn-ims-values.yaml
+++ b/roles/core/templates/cdac5gc-5g-multiple-dnn-ims-values.yaml
@@ -31,6 +31,8 @@ omec-control-plane:
 
   kafka:
     deploy: true
+    image:
+      repository: bitnamilegacy/kafka
 
   mongodb:
     usePassword: false
@@ -38,6 +40,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false

--- a/roles/core/templates/cdac5gc-5g-values.yaml
+++ b/roles/core/templates/cdac5gc-5g-values.yaml
@@ -31,6 +31,8 @@ omec-control-plane:
 
   kafka:
     deploy: true
+    image:
+      repository: bitnamilegacy/kafka
 
   mongodb:
     usePassword: false
@@ -38,6 +40,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false

--- a/roles/core/templates/ios-mcn-sriov.yaml
+++ b/roles/core/templates/ios-mcn-sriov.yaml
@@ -34,6 +34,8 @@ omec-control-plane:
 
   kafka:
     deploy: true
+    image:
+      repository: bitnamilegacy/kafka
 
   mongodb:
     usePassword: false
@@ -41,6 +43,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false

--- a/roles/core/templates/iosmcn-5g-multiple-dnn-ims-values.yaml
+++ b/roles/core/templates/iosmcn-5g-multiple-dnn-ims-values.yaml
@@ -31,6 +31,8 @@ omec-control-plane:
 
   kafka:
     deploy: true
+    image:
+      repository: bitnamilegacy/kafka
 
   mongodb:
     usePassword: false
@@ -38,6 +40,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false

--- a/roles/core/templates/iosmcn-5g-values.yaml
+++ b/roles/core/templates/iosmcn-5g-values.yaml
@@ -32,6 +32,8 @@ omec-control-plane:
 
   kafka:
     deploy: true
+    image:
+      repository: bitnamilegacy/kafka
 
   mongodb:
     usePassword: false
@@ -39,6 +41,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false

--- a/roles/core/templates/radio-5g-values.yaml
+++ b/roles/core/templates/radio-5g-values.yaml
@@ -23,6 +23,8 @@ omec-control-plane:
 
   kafka:
     deploy: true
+    image:
+      repository: bitnamilegacy/kafka
 
   mongodb:
     usePassword: false
@@ -30,6 +32,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false

--- a/roles/core/templates/sdcore-5g-values.yaml
+++ b/roles/core/templates/sdcore-5g-values.yaml
@@ -23,6 +23,8 @@ omec-control-plane:
 
   kafka:
     deploy: true
+    image:
+      repository: bitnamilegacy/kafka
 
   mongodb:
     usePassword: false
@@ -30,6 +32,8 @@ omec-control-plane:
       enabled: false
     architecture: replicaset
     replicaCount: 2
+    image:
+      repository: bitnamilegacy/mongodb
 
   resources:
     enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind enhancement

**What this PR does / why we need it**:
An image pullback occurred in Kafka and MongoDB because, starting August 28th, all existing container images (including older or versioned tags such as `2.50.0`, `10.6`) are being migrated from the public catalog (`docker.io/bitnami`) to the *Bitnami Legacy* repository (`docker.io/bitnamilegacy`). Images in the legacy repository will no longer receive updates, which caused the pullback issue.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #7

**Test Report Added?**:
> /kind TESTED


